### PR TITLE
fix: configure reattach provider via TF_PID & TF_ADDR

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,14 +13,14 @@
             "args": [
                 "--debug",
                 "--terraform-version=1.3.3",
-                "--terraform-provider-version=0.21.0",
+                "--terraform-provider-version=0.23.5",
                 "--terraform-provider-source=spectrocloud/spectrocloud"
             ],
             "env": {
-                "KUBECONFIG": "",
+                "KUBECONFIG": "/Users/tylergillson/Downloads/hub.kubeconfig",
                 "UPBOUND_CONTEXT": "local",
-                "TF_PID": "",
-                "TF_ADDR": "",
+                "TF_PID": "40348",
+                "TF_ADDR": "/var/folders/w1/sm7f2fb959j2xkxln196ksj40000gn/T/plugin2952085873",
             },
             // "showLog": true,
             // "trace": "verbose",

--- a/cmd/provider/run/run.go
+++ b/cmd/provider/run/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/crossplane-contrib/provider-palette/internal/clients"
 	"github.com/crossplane-contrib/provider-palette/internal/controller"
 	"github.com/crossplane-contrib/provider-palette/internal/features"
+	"github.com/crossplane-contrib/provider-palette/internal/utils"
 )
 
 var cancel context.CancelFunc
@@ -62,6 +63,10 @@ func Run() {
 	}
 
 	log.Debug("Starting")
+
+	// If TF_PID and TF_ADDR are set, configure the TF_REATTACH_PROVIDERS environment variable
+	err := utils.ConfigureTFReattachProvider()
+	kingpin.FatalIfError(err, "Cannot configure TF_REATTACH_PROVIDERS")
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")

--- a/internal/utils/terraform.go
+++ b/internal/utils/terraform.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+// ConfigureTFReattachProvider configures the TF_REATTACH_PROVIDERS environment variable
+func ConfigureTFReattachProvider() error {
+	addr := os.Getenv("TF_ADDR")
+	pid := os.Getenv("TF_PID")
+	if addr == "" || pid == "" {
+		return nil
+	}
+	reattachProvider := fmt.Sprintf(`{
+		"registry.terraform.io/spectrocloud/spectrocloud": {
+			"Protocol": "grpc",
+			"ProtocolVersion": 5,
+			"Pid": %s,
+			"Test": true,
+			"Addr": {
+				"Network": "unix",
+				"String": "%s"
+			}
+		}
+	}`, pid, addr)
+	return os.Setenv("TF_REATTACH_PROVIDERS", reattachProvider)
+}

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -44,25 +44,9 @@ var (
 )
 
 func init() {
-	// Configure TF_REATTACH_PROVIDERS
-	addr := os.Getenv("TF_ADDR")
-	pid := os.Getenv("TF_PID")
-	if addr == "" || pid == "" {
-		return
+	if err := utils.ConfigureTFReattachProvider(); err != nil {
+		panic(err)
 	}
-	reattachProvider := fmt.Sprintf(`{
-		"registry.terraform.io/spectrocloud/spectrocloud": {
-			"Protocol": "grpc",
-			"ProtocolVersion": 5,
-			"Pid": %s,
-			"Test": true,
-			"Addr": {
-				"Network": "unix",
-				"String": "%s"
-			}
-		}
-	}`, pid, addr)
-	os.Setenv("TF_REATTACH_PROVIDERS", reattachProvider)
 }
 
 func TestFunctionality(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes an issue where `TF_PID` and `TF_ADDR` were not being respected (used to construct `TF_REATTACH_PROVIDERS`) when running the provider in debug mode via the `Debug` launch config.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
