### PR TITLE
override spectrocloud_cloudaccount_aws to set aws_access_key as sensitive

### DIFF
--- a/apis/cluster/cloudaccount/v1alpha1/zz_aws_terraformed.go
+++ b/apis/cluster/cloudaccount/v1alpha1/zz_aws_terraformed.go
@@ -21,7 +21,7 @@ func (mg *Aws) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this Aws
 func (tr *Aws) GetConnectionDetailsMapping() map[string]string {
-	return map[string]string{"aws_secret_key": "awsSecretKeySecretRef", "external_id": "externalIdSecretRef"}
+	return map[string]string{"aws_access_key": "awsAccessKeySecretRef", "aws_secret_key": "awsSecretKeySecretRef", "external_id": "externalIdSecretRef"}
 }
 
 // GetObservation of this Aws

--- a/apis/cluster/cloudaccount/v1alpha1/zz_aws_types.go
+++ b/apis/cluster/cloudaccount/v1alpha1/zz_aws_types.go
@@ -21,7 +21,7 @@ type AwsInitParameters struct {
 
 	// (String) The AWS access key used to authenticate.
 	// The AWS access key used to authenticate.
-	AwsAccessKey *string `json:"awsAccessKey,omitempty" tf:"aws_access_key,omitempty"`
+	AwsAccessKeySecretRef *v1.SecretKeySelector `json:"awsAccessKeySecretRef,omitempty" tf:"-"`
 
 	// (String, Sensitive) The AWS secret key used in conjunction with the access key for authentication.
 	// The AWS secret key used in conjunction with the access key for authentication.
@@ -65,10 +65,6 @@ type AwsObservation struct {
 	// The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
 	Arn *string `json:"arn,omitempty" tf:"arn,omitempty"`
 
-	// (String) The AWS access key used to authenticate.
-	// The AWS access key used to authenticate.
-	AwsAccessKey *string `json:"awsAccessKey,omitempty" tf:"aws_access_key,omitempty"`
-
 	// (String) The context of the AWS configuration. Allowed values are project or tenant. Default value is project. If  the project context is specified, the project name will sourced from the provider configuration parameter project_name.
 	// The context of the AWS configuration. Allowed values are `project` or `tenant`. Default value is `project`. If  the `project` context is specified, the project name will sourced from the provider configuration parameter [`project_name`](https://registry.io/providers/spectrocloud/spectrocloud/latest/docs#schema).
 	Context *string `json:"context,omitempty" tf:"context,omitempty"`
@@ -110,7 +106,7 @@ type AwsParameters struct {
 	// (String) The AWS access key used to authenticate.
 	// The AWS access key used to authenticate.
 	// +kubebuilder:validation:Optional
-	AwsAccessKey *string `json:"awsAccessKey,omitempty" tf:"aws_access_key,omitempty"`
+	AwsAccessKeySecretRef *v1.SecretKeySelector `json:"awsAccessKeySecretRef,omitempty" tf:"-"`
 
 	// (String, Sensitive) The AWS secret key used in conjunction with the access key for authentication.
 	// The AWS secret key used in conjunction with the access key for authentication.

--- a/apis/cluster/cloudaccount/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/cloudaccount/v1alpha1/zz_generated.deepcopy.go
@@ -48,9 +48,9 @@ func (in *AwsInitParameters) DeepCopyInto(out *AwsInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.AwsAccessKey != nil {
-		in, out := &in.AwsAccessKey, &out.AwsAccessKey
-		*out = new(string)
+	if in.AwsAccessKeySecretRef != nil {
+		in, out := &in.AwsAccessKeySecretRef, &out.AwsAccessKeySecretRef
+		*out = new(v1.SecretKeySelector)
 		**out = **in
 	}
 	if in.AwsSecretKeySecretRef != nil {
@@ -151,11 +151,6 @@ func (in *AwsObservation) DeepCopyInto(out *AwsObservation) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.AwsAccessKey != nil {
-		in, out := &in.AwsAccessKey, &out.AwsAccessKey
-		*out = new(string)
-		**out = **in
-	}
 	if in.Context != nil {
 		in, out := &in.Context, &out.Context
 		*out = new(string)
@@ -217,9 +212,9 @@ func (in *AwsParameters) DeepCopyInto(out *AwsParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.AwsAccessKey != nil {
-		in, out := &in.AwsAccessKey, &out.AwsAccessKey
-		*out = new(string)
+	if in.AwsAccessKeySecretRef != nil {
+		in, out := &in.AwsAccessKeySecretRef, &out.AwsAccessKeySecretRef
+		*out = new(v1.SecretKeySelector)
 		**out = **in
 	}
 	if in.AwsSecretKeySecretRef != nil {

--- a/apis/cluster/spectrocloud/v1alpha1/zz_sso_types.go
+++ b/apis/cluster/spectrocloud/v1alpha1/zz_sso_types.go
@@ -28,11 +28,11 @@ type OidcInitParameters struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
@@ -48,7 +48,7 @@ type OidcInitParameters struct {
 	// URL of the OIDC issuer.
 	IssuerURL *string `json:"issuerUrl,omitempty" tf:"issuer_url,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
@@ -57,7 +57,7 @@ type OidcInitParameters struct {
 	// +listType=set
 	Scopes []*string `json:"scopes,omitempty" tf:"scopes,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 
@@ -81,11 +81,11 @@ type OidcObservation struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
@@ -101,7 +101,7 @@ type OidcObservation struct {
 	// URL of the OIDC issuer.
 	IssuerURL *string `json:"issuerUrl,omitempty" tf:"issuer_url,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
@@ -114,7 +114,7 @@ type OidcObservation struct {
 	// +listType=set
 	Scopes []*string `json:"scopes,omitempty" tf:"scopes,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 
@@ -141,12 +141,12 @@ type OidcParameters struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	// +kubebuilder:validation:Optional
 	Email *string `json:"email" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	// +kubebuilder:validation:Optional
 	FirstName *string `json:"firstName" tf:"first_name,omitempty"`
@@ -166,7 +166,7 @@ type OidcParameters struct {
 	// +kubebuilder:validation:Optional
 	IssuerURL *string `json:"issuerUrl" tf:"issuer_url,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	// +kubebuilder:validation:Optional
 	LastName *string `json:"lastName" tf:"last_name,omitempty"`
@@ -177,7 +177,7 @@ type OidcParameters struct {
 	// +listType=set
 	Scopes []*string `json:"scopes" tf:"scopes,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	// +kubebuilder:validation:Optional
 	SpectroTeam *string `json:"spectroTeam" tf:"spectro_team,omitempty"`
@@ -195,7 +195,7 @@ type SAMLInitParameters struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// User's email address retrieved from identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
@@ -203,7 +203,7 @@ type SAMLInitParameters struct {
 	// Boolean to enable SAML single logout feature.
 	EnableSingleLogout *bool `json:"enableSingleLogout,omitempty" tf:"enable_single_logout,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// User's first name retrieved from identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
@@ -211,7 +211,7 @@ type SAMLInitParameters struct {
 	// Metadata XML of the SAML identity provider.
 	IdentityProviderMetadata *string `json:"identityProviderMetadata,omitempty" tf:"identity_provider_metadata,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// User's last name retrieved from identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
@@ -223,7 +223,7 @@ type SAMLInitParameters struct {
 	// The identity provider service used for SAML authentication.
 	ServiceProvider *string `json:"serviceProvider,omitempty" tf:"service_provider,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The SpectroCloud team the user belongs to.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 }
@@ -239,7 +239,7 @@ type SAMLObservation struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// User's email address retrieved from identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
@@ -251,7 +251,7 @@ type SAMLObservation struct {
 	// Entity ID used to identify the service provider.
 	EntityID *string `json:"entityId,omitempty" tf:"entity_id,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// User's first name retrieved from identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
@@ -263,7 +263,7 @@ type SAMLObservation struct {
 	// SAML identity provider issuer URL.
 	Issuer *string `json:"issuer,omitempty" tf:"issuer,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// User's last name retrieved from identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
@@ -287,7 +287,7 @@ type SAMLObservation struct {
 	// URL used for initiating SAML single logout.
 	SingleLogoutURL *string `json:"singleLogoutUrl,omitempty" tf:"single_logout_url,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The SpectroCloud team the user belongs to.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 }
@@ -300,7 +300,7 @@ type SAMLParameters struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// User's email address retrieved from identity provider.
 	// +kubebuilder:validation:Optional
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
@@ -310,7 +310,7 @@ type SAMLParameters struct {
 	// +kubebuilder:validation:Optional
 	EnableSingleLogout *bool `json:"enableSingleLogout,omitempty" tf:"enable_single_logout,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// User's first name retrieved from identity provider.
 	// +kubebuilder:validation:Optional
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
@@ -320,7 +320,7 @@ type SAMLParameters struct {
 	// +kubebuilder:validation:Optional
 	IdentityProviderMetadata *string `json:"identityProviderMetadata" tf:"identity_provider_metadata,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// User's last name retrieved from identity provider.
 	// +kubebuilder:validation:Optional
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
@@ -335,7 +335,7 @@ type SAMLParameters struct {
 	// +kubebuilder:validation:Optional
 	ServiceProvider *string `json:"serviceProvider" tf:"service_provider,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The SpectroCloud team the user belongs to.
 	// +kubebuilder:validation:Optional
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
@@ -423,60 +423,60 @@ type SsoParameters struct {
 
 type UserInfoEndpointInitParameters struct {
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 }
 
 type UserInfoEndpointObservation struct {
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 }
 
 type UserInfoEndpointParameters struct {
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	// +kubebuilder:validation:Optional
 	Email *string `json:"email" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	// +kubebuilder:validation:Optional
 	FirstName *string `json:"firstName" tf:"first_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	// +kubebuilder:validation:Optional
 	LastName *string `json:"lastName" tf:"last_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	// +kubebuilder:validation:Optional
 	SpectroTeam *string `json:"spectroTeam" tf:"spectro_team,omitempty"`

--- a/apis/namespaced/cloudaccount/v1alpha1/zz_aws_terraformed.go
+++ b/apis/namespaced/cloudaccount/v1alpha1/zz_aws_terraformed.go
@@ -21,7 +21,7 @@ func (mg *Aws) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this Aws
 func (tr *Aws) GetConnectionDetailsMapping() map[string]string {
-	return map[string]string{"aws_secret_key": "awsSecretKeySecretRef", "external_id": "externalIdSecretRef"}
+	return map[string]string{"aws_access_key": "awsAccessKeySecretRef", "aws_secret_key": "awsSecretKeySecretRef", "external_id": "externalIdSecretRef"}
 }
 
 // GetObservation of this Aws

--- a/apis/namespaced/cloudaccount/v1alpha1/zz_aws_types.go
+++ b/apis/namespaced/cloudaccount/v1alpha1/zz_aws_types.go
@@ -22,7 +22,7 @@ type AwsInitParameters struct {
 
 	// (String) The AWS access key used to authenticate.
 	// The AWS access key used to authenticate.
-	AwsAccessKey *string `json:"awsAccessKey,omitempty" tf:"aws_access_key,omitempty"`
+	AwsAccessKeySecretRef *v1.LocalSecretKeySelector `json:"awsAccessKeySecretRef,omitempty" tf:"-"`
 
 	// (String, Sensitive) The AWS secret key used in conjunction with the access key for authentication.
 	// The AWS secret key used in conjunction with the access key for authentication.
@@ -66,10 +66,6 @@ type AwsObservation struct {
 	// The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
 	Arn *string `json:"arn,omitempty" tf:"arn,omitempty"`
 
-	// (String) The AWS access key used to authenticate.
-	// The AWS access key used to authenticate.
-	AwsAccessKey *string `json:"awsAccessKey,omitempty" tf:"aws_access_key,omitempty"`
-
 	// (String) The context of the AWS configuration. Allowed values are project or tenant. Default value is project. If  the project context is specified, the project name will sourced from the provider configuration parameter project_name.
 	// The context of the AWS configuration. Allowed values are `project` or `tenant`. Default value is `project`. If  the `project` context is specified, the project name will sourced from the provider configuration parameter [`project_name`](https://registry.io/providers/spectrocloud/spectrocloud/latest/docs#schema).
 	Context *string `json:"context,omitempty" tf:"context,omitempty"`
@@ -111,7 +107,7 @@ type AwsParameters struct {
 	// (String) The AWS access key used to authenticate.
 	// The AWS access key used to authenticate.
 	// +kubebuilder:validation:Optional
-	AwsAccessKey *string `json:"awsAccessKey,omitempty" tf:"aws_access_key,omitempty"`
+	AwsAccessKeySecretRef *v1.LocalSecretKeySelector `json:"awsAccessKeySecretRef,omitempty" tf:"-"`
 
 	// (String, Sensitive) The AWS secret key used in conjunction with the access key for authentication.
 	// The AWS secret key used in conjunction with the access key for authentication.

--- a/apis/namespaced/cloudaccount/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/cloudaccount/v1alpha1/zz_generated.deepcopy.go
@@ -48,9 +48,9 @@ func (in *AwsInitParameters) DeepCopyInto(out *AwsInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.AwsAccessKey != nil {
-		in, out := &in.AwsAccessKey, &out.AwsAccessKey
-		*out = new(string)
+	if in.AwsAccessKeySecretRef != nil {
+		in, out := &in.AwsAccessKeySecretRef, &out.AwsAccessKeySecretRef
+		*out = new(v1.LocalSecretKeySelector)
 		**out = **in
 	}
 	if in.AwsSecretKeySecretRef != nil {
@@ -151,11 +151,6 @@ func (in *AwsObservation) DeepCopyInto(out *AwsObservation) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.AwsAccessKey != nil {
-		in, out := &in.AwsAccessKey, &out.AwsAccessKey
-		*out = new(string)
-		**out = **in
-	}
 	if in.Context != nil {
 		in, out := &in.Context, &out.Context
 		*out = new(string)
@@ -217,9 +212,9 @@ func (in *AwsParameters) DeepCopyInto(out *AwsParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.AwsAccessKey != nil {
-		in, out := &in.AwsAccessKey, &out.AwsAccessKey
-		*out = new(string)
+	if in.AwsAccessKeySecretRef != nil {
+		in, out := &in.AwsAccessKeySecretRef, &out.AwsAccessKeySecretRef
+		*out = new(v1.LocalSecretKeySelector)
 		**out = **in
 	}
 	if in.AwsSecretKeySecretRef != nil {

--- a/apis/namespaced/spectrocloud/v1alpha1/zz_sso_types.go
+++ b/apis/namespaced/spectrocloud/v1alpha1/zz_sso_types.go
@@ -29,11 +29,11 @@ type OidcInitParameters struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
@@ -49,7 +49,7 @@ type OidcInitParameters struct {
 	// URL of the OIDC issuer.
 	IssuerURL *string `json:"issuerUrl,omitempty" tf:"issuer_url,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
@@ -58,7 +58,7 @@ type OidcInitParameters struct {
 	// +listType=set
 	Scopes []*string `json:"scopes,omitempty" tf:"scopes,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 
@@ -82,11 +82,11 @@ type OidcObservation struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
@@ -102,7 +102,7 @@ type OidcObservation struct {
 	// URL of the OIDC issuer.
 	IssuerURL *string `json:"issuerUrl,omitempty" tf:"issuer_url,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
@@ -115,7 +115,7 @@ type OidcObservation struct {
 	// +listType=set
 	Scopes []*string `json:"scopes,omitempty" tf:"scopes,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 
@@ -142,12 +142,12 @@ type OidcParameters struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	// +kubebuilder:validation:Optional
 	Email *string `json:"email" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	// +kubebuilder:validation:Optional
 	FirstName *string `json:"firstName" tf:"first_name,omitempty"`
@@ -167,7 +167,7 @@ type OidcParameters struct {
 	// +kubebuilder:validation:Optional
 	IssuerURL *string `json:"issuerUrl" tf:"issuer_url,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	// +kubebuilder:validation:Optional
 	LastName *string `json:"lastName" tf:"last_name,omitempty"`
@@ -178,7 +178,7 @@ type OidcParameters struct {
 	// +listType=set
 	Scopes []*string `json:"scopes" tf:"scopes,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	// +kubebuilder:validation:Optional
 	SpectroTeam *string `json:"spectroTeam" tf:"spectro_team,omitempty"`
@@ -196,7 +196,7 @@ type SAMLInitParameters struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// User's email address retrieved from identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
@@ -204,7 +204,7 @@ type SAMLInitParameters struct {
 	// Boolean to enable SAML single logout feature.
 	EnableSingleLogout *bool `json:"enableSingleLogout,omitempty" tf:"enable_single_logout,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// User's first name retrieved from identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
@@ -212,7 +212,7 @@ type SAMLInitParameters struct {
 	// Metadata XML of the SAML identity provider.
 	IdentityProviderMetadata *string `json:"identityProviderMetadata,omitempty" tf:"identity_provider_metadata,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// User's last name retrieved from identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
@@ -224,7 +224,7 @@ type SAMLInitParameters struct {
 	// The identity provider service used for SAML authentication.
 	ServiceProvider *string `json:"serviceProvider,omitempty" tf:"service_provider,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The SpectroCloud team the user belongs to.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 }
@@ -240,7 +240,7 @@ type SAMLObservation struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// User's email address retrieved from identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
@@ -252,7 +252,7 @@ type SAMLObservation struct {
 	// Entity ID used to identify the service provider.
 	EntityID *string `json:"entityId,omitempty" tf:"entity_id,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// User's first name retrieved from identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
@@ -264,7 +264,7 @@ type SAMLObservation struct {
 	// SAML identity provider issuer URL.
 	Issuer *string `json:"issuer,omitempty" tf:"issuer,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// User's last name retrieved from identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
@@ -288,7 +288,7 @@ type SAMLObservation struct {
 	// URL used for initiating SAML single logout.
 	SingleLogoutURL *string `json:"singleLogoutUrl,omitempty" tf:"single_logout_url,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The SpectroCloud team the user belongs to.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 }
@@ -301,7 +301,7 @@ type SAMLParameters struct {
 	// +listType=set
 	DefaultTeamIds []*string `json:"defaultTeamIds,omitempty" tf:"default_team_ids,omitempty"`
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// User's email address retrieved from identity provider.
 	// +kubebuilder:validation:Optional
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
@@ -311,7 +311,7 @@ type SAMLParameters struct {
 	// +kubebuilder:validation:Optional
 	EnableSingleLogout *bool `json:"enableSingleLogout,omitempty" tf:"enable_single_logout,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// User's first name retrieved from identity provider.
 	// +kubebuilder:validation:Optional
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
@@ -321,7 +321,7 @@ type SAMLParameters struct {
 	// +kubebuilder:validation:Optional
 	IdentityProviderMetadata *string `json:"identityProviderMetadata" tf:"identity_provider_metadata,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// User's last name retrieved from identity provider.
 	// +kubebuilder:validation:Optional
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
@@ -336,7 +336,7 @@ type SAMLParameters struct {
 	// +kubebuilder:validation:Optional
 	ServiceProvider *string `json:"serviceProvider" tf:"service_provider,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The SpectroCloud team the user belongs to.
 	// +kubebuilder:validation:Optional
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
@@ -424,60 +424,60 @@ type SsoParameters struct {
 
 type UserInfoEndpointInitParameters struct {
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 }
 
 type UserInfoEndpointObservation struct {
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	Email *string `json:"email,omitempty" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	FirstName *string `json:"firstName,omitempty" tf:"first_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	LastName *string `json:"lastName,omitempty" tf:"last_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	SpectroTeam *string `json:"spectroTeam,omitempty" tf:"spectro_team,omitempty"`
 }
 
 type UserInfoEndpointParameters struct {
 
-	// (String) The name of the claim that returns the user's email address from the identity provider.
+	// (String) User's email address retrieved from identity provider.
 	// The name of the claim that returns the user's email address from the identity provider.
 	// +kubebuilder:validation:Optional
 	Email *string `json:"email" tf:"email,omitempty"`
 
-	// (String) The name of the claim that returns the user's first name from the identity provider.
+	// (String) User's first name retrieved from identity provider.
 	// The name of the claim that returns the user's first name from the identity provider.
 	// +kubebuilder:validation:Optional
 	FirstName *string `json:"firstName" tf:"first_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's last name from the identity provider.
+	// (String) User's last name retrieved from identity provider.
 	// The name of the claim that returns the user's last name from the identity provider.
 	// +kubebuilder:validation:Optional
 	LastName *string `json:"lastName" tf:"last_name,omitempty"`
 
-	// (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+	// (String) The SpectroCloud team the user belongs to.
 	// The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
 	// +kubebuilder:validation:Optional
 	SpectroTeam *string `json:"spectroTeam" tf:"spectro_team,omitempty"`

--- a/config/common/config.go
+++ b/config/common/config.go
@@ -365,7 +365,9 @@ func configureClusterResources(p *config.Provider) {
 	p.AddResourceConfigurator("spectrocloud_cloudaccount_custom", func(r *config.Resource) {})
 
 	// AWS resources
-	p.AddResourceConfigurator("spectrocloud_cloudaccount_aws", func(r *config.Resource) {})
+	p.AddResourceConfigurator("spectrocloud_cloudaccount_aws", func(r *config.Resource) {
+		r.TerraformResource.Schema["aws_access_key"].Sensitive = true
+	})
 
 	p.AddResourceConfigurator("spectrocloud_cluster_aws", func(r *config.Resource) {
 		r.UseAsync = true

--- a/config/provider-metadata.yaml
+++ b/config/provider-metadata.yaml
@@ -3512,17 +3512,17 @@ resources:
             default_team_ids: (Set of String) A set of default team IDs assigned to users.
             delete: (String)
             domains: (Set of String) A set of domains associated with the SSO configuration.
-            email: (String) The name of the claim that returns the user's email address from the identity provider.
+            email: (String) User's email address retrieved from identity provider.
             enable_single_logout: (Boolean) Boolean to enable SAML single logout feature.
             entity_id: (String) Entity ID used to identify the service provider.
-            first_name: (String) The name of the claim that returns the user's first name from the identity provider.
+            first_name: (String) User's first name retrieved from identity provider.
             id: (String) The ID of this resource.
             identity_provider_ca_certificate: (String) Certificate authority (CA) certificate for the identity provider.
             identity_provider_metadata: (String) Metadata XML of the SAML identity provider.
             insecure_skip_tls_verify: (Boolean) Boolean to skip TLS verification for identity provider communication.
             issuer: (String) SAML identity provider issuer URL.
             issuer_url: (String) URL of the OIDC issuer.
-            last_name: (String) The name of the claim that returns the user's last name from the identity provider.
+            last_name: (String) User's last name retrieved from identity provider.
             login_url: (String) Login URL for the SAML identity provider.
             logout_url: (String) URL used for logging out of the OIDC session.
             name_id_format: (String) Format of the NameID attribute in SAML responses.
@@ -3532,7 +3532,7 @@ resources:
             service_provider: (String) The identity provider service used for SAML authentication.
             service_provider_metadata: (String) Metadata XML of the SAML service provider.
             single_logout_url: (String) URL used for initiating SAML single logout.
-            spectro_team: (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+            spectro_team: (String) The SpectroCloud team the user belongs to.
             sso_auth_type: '(String) Defines the type of SSO authentication. Supported values: none, saml, oidc.'
             timeouts: (Block, Optional) (see below for nested schema)
             update: (String)

--- a/examples-generated/cluster/cloudaccount/v1alpha1/aws.yaml
+++ b/examples-generated/cluster/cloudaccount/v1alpha1/aws.yaml
@@ -8,7 +8,10 @@ metadata:
   name: aws-1
 spec:
   forProvider:
-    awsAccessKey: ${var.aws_access_key}
+    awsAccessKeySecretRef:
+      key: example-key
+      name: example-secret
+      namespace: upbound-system
     awsSecretKeySecretRef:
       key: example-key
       name: example-secret

--- a/examples-generated/namespaced/cloudaccount/v1alpha1/aws.yaml
+++ b/examples-generated/namespaced/cloudaccount/v1alpha1/aws.yaml
@@ -9,7 +9,9 @@ metadata:
   namespace: upbound-system
 spec:
   forProvider:
-    awsAccessKey: ${var.aws_access_key}
+    awsAccessKeySecretRef:
+      key: example-key
+      name: example-secret
     awsSecretKeySecretRef:
       key: example-key
       name: example-secret

--- a/package/crds/cloudaccount.palette.crossplane.io_aws.yaml
+++ b/package/crds/cloudaccount.palette.crossplane.io_aws.yaml
@@ -77,11 +77,25 @@ spec:
                       (String) The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                       The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                     type: string
-                  awsAccessKey:
+                  awsAccessKeySecretRef:
                     description: |-
                       (String) The AWS access key used to authenticate.
                       The AWS access key used to authenticate.
-                    type: string
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   awsSecretKeySecretRef:
                     description: |-
                       (String, Sensitive) The AWS secret key used in conjunction with the access key for authentication.
@@ -173,11 +187,25 @@ spec:
                       (String) The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                       The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                     type: string
-                  awsAccessKey:
+                  awsAccessKeySecretRef:
                     description: |-
                       (String) The AWS access key used to authenticate.
                       The AWS access key used to authenticate.
-                    type: string
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
                   awsSecretKeySecretRef:
                     description: |-
                       (String, Sensitive) The AWS secret key used in conjunction with the access key for authentication.
@@ -351,11 +379,6 @@ spec:
                     description: |-
                       (String) The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                       The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
-                    type: string
-                  awsAccessKey:
-                    description: |-
-                      (String) The AWS access key used to authenticate.
-                      The AWS access key used to authenticate.
                     type: string
                   context:
                     description: |-

--- a/package/crds/cloudaccount.palette.m.crossplane.io_aws.yaml
+++ b/package/crds/cloudaccount.palette.m.crossplane.io_aws.yaml
@@ -63,11 +63,20 @@ spec:
                       (String) The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                       The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                     type: string
-                  awsAccessKey:
+                  awsAccessKeySecretRef:
                     description: |-
                       (String) The AWS access key used to authenticate.
                       The AWS access key used to authenticate.
-                    type: string
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   awsSecretKeySecretRef:
                     description: |-
                       (String, Sensitive) The AWS secret key used in conjunction with the access key for authentication.
@@ -149,11 +158,20 @@ spec:
                       (String) The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                       The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                     type: string
-                  awsAccessKey:
+                  awsAccessKeySecretRef:
                     description: |-
                       (String) The AWS access key used to authenticate.
                       The AWS access key used to authenticate.
-                    type: string
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   awsSecretKeySecretRef:
                     description: |-
                       (String, Sensitive) The AWS secret key used in conjunction with the access key for authentication.
@@ -289,11 +307,6 @@ spec:
                     description: |-
                       (String) The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
                       The Amazon Resource Name (ARN) associated with the AWS resource. This is used for identifying resources in AWS.
-                    type: string
-                  awsAccessKey:
-                    description: |-
-                      (String) The AWS access key used to authenticate.
-                      The AWS access key used to authenticate.
                     type: string
                   context:
                     description: |-

--- a/package/crds/spectrocloud.palette.crossplane.io_ssoes.yaml
+++ b/package/crds/spectrocloud.palette.crossplane.io_ssoes.yaml
@@ -126,12 +126,12 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             The name of the claim that returns the user's email address from the identity provider.
                           type: string
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             The name of the claim that returns the user's first name from the identity provider.
                           type: string
                         identityProviderCaCertificate:
@@ -151,7 +151,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             The name of the claim that returns the user's last name from the identity provider.
                           type: string
                         scopes:
@@ -164,7 +164,7 @@ spec:
                           x-kubernetes-list-type: set
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                           type: string
                         userInfoEndpoint:
@@ -175,22 +175,22 @@ spec:
                             properties:
                               email:
                                 description: |-
-                                  (String) The name of the claim that returns the user's email address from the identity provider.
+                                  (String) User's email address retrieved from identity provider.
                                   The name of the claim that returns the user's email address from the identity provider.
                                 type: string
                               firstName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's first name from the identity provider.
+                                  (String) User's first name retrieved from identity provider.
                                   The name of the claim that returns the user's first name from the identity provider.
                                 type: string
                               lastName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's last name from the identity provider.
+                                  (String) User's last name retrieved from identity provider.
                                   The name of the claim that returns the user's last name from the identity provider.
                                 type: string
                               spectroTeam:
                                 description: |-
-                                  (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                                  (String) The SpectroCloud team the user belongs to.
                                   The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                                 type: string
                             type: object
@@ -213,7 +213,7 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             User's email address retrieved from identity provider.
                           type: string
                         enableSingleLogout:
@@ -223,7 +223,7 @@ spec:
                           type: boolean
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             User's first name retrieved from identity provider.
                           type: string
                         identityProviderMetadata:
@@ -233,7 +233,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             User's last name retrieved from identity provider.
                           type: string
                         nameIdFormat:
@@ -248,7 +248,7 @@ spec:
                           type: string
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The SpectroCloud team the user belongs to.
                           type: string
                       type: object
@@ -326,12 +326,12 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             The name of the claim that returns the user's email address from the identity provider.
                           type: string
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             The name of the claim that returns the user's first name from the identity provider.
                           type: string
                         identityProviderCaCertificate:
@@ -351,7 +351,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             The name of the claim that returns the user's last name from the identity provider.
                           type: string
                         scopes:
@@ -364,7 +364,7 @@ spec:
                           x-kubernetes-list-type: set
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                           type: string
                         userInfoEndpoint:
@@ -375,22 +375,22 @@ spec:
                             properties:
                               email:
                                 description: |-
-                                  (String) The name of the claim that returns the user's email address from the identity provider.
+                                  (String) User's email address retrieved from identity provider.
                                   The name of the claim that returns the user's email address from the identity provider.
                                 type: string
                               firstName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's first name from the identity provider.
+                                  (String) User's first name retrieved from identity provider.
                                   The name of the claim that returns the user's first name from the identity provider.
                                 type: string
                               lastName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's last name from the identity provider.
+                                  (String) User's last name retrieved from identity provider.
                                   The name of the claim that returns the user's last name from the identity provider.
                                 type: string
                               spectroTeam:
                                 description: |-
-                                  (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                                  (String) The SpectroCloud team the user belongs to.
                                   The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                                 type: string
                             type: object
@@ -415,7 +415,7 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             User's email address retrieved from identity provider.
                           type: string
                         enableSingleLogout:
@@ -425,7 +425,7 @@ spec:
                           type: boolean
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             User's first name retrieved from identity provider.
                           type: string
                         identityProviderMetadata:
@@ -435,7 +435,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             User's last name retrieved from identity provider.
                           type: string
                         nameIdFormat:
@@ -450,7 +450,7 @@ spec:
                           type: string
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The SpectroCloud team the user belongs to.
                           type: string
                       type: object
@@ -595,12 +595,12 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             The name of the claim that returns the user's email address from the identity provider.
                           type: string
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             The name of the claim that returns the user's first name from the identity provider.
                           type: string
                         identityProviderCaCertificate:
@@ -620,7 +620,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             The name of the claim that returns the user's last name from the identity provider.
                           type: string
                         logoutUrl:
@@ -638,7 +638,7 @@ spec:
                           x-kubernetes-list-type: set
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                           type: string
                         userInfoEndpoint:
@@ -649,22 +649,22 @@ spec:
                             properties:
                               email:
                                 description: |-
-                                  (String) The name of the claim that returns the user's email address from the identity provider.
+                                  (String) User's email address retrieved from identity provider.
                                   The name of the claim that returns the user's email address from the identity provider.
                                 type: string
                               firstName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's first name from the identity provider.
+                                  (String) User's first name retrieved from identity provider.
                                   The name of the claim that returns the user's first name from the identity provider.
                                 type: string
                               lastName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's last name from the identity provider.
+                                  (String) User's last name retrieved from identity provider.
                                   The name of the claim that returns the user's last name from the identity provider.
                                 type: string
                               spectroTeam:
                                 description: |-
-                                  (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                                  (String) The SpectroCloud team the user belongs to.
                                   The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                                 type: string
                             type: object
@@ -692,7 +692,7 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             User's email address retrieved from identity provider.
                           type: string
                         enableSingleLogout:
@@ -707,7 +707,7 @@ spec:
                           type: string
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             User's first name retrieved from identity provider.
                           type: string
                         identityProviderMetadata:
@@ -722,7 +722,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             User's last name retrieved from identity provider.
                           type: string
                         loginUrl:
@@ -752,7 +752,7 @@ spec:
                           type: string
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The SpectroCloud team the user belongs to.
                           type: string
                       type: object

--- a/package/crds/spectrocloud.palette.m.crossplane.io_ssoes.yaml
+++ b/package/crds/spectrocloud.palette.m.crossplane.io_ssoes.yaml
@@ -107,12 +107,12 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             The name of the claim that returns the user's email address from the identity provider.
                           type: string
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             The name of the claim that returns the user's first name from the identity provider.
                           type: string
                         identityProviderCaCertificate:
@@ -132,7 +132,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             The name of the claim that returns the user's last name from the identity provider.
                           type: string
                         scopes:
@@ -145,7 +145,7 @@ spec:
                           x-kubernetes-list-type: set
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                           type: string
                         userInfoEndpoint:
@@ -156,22 +156,22 @@ spec:
                             properties:
                               email:
                                 description: |-
-                                  (String) The name of the claim that returns the user's email address from the identity provider.
+                                  (String) User's email address retrieved from identity provider.
                                   The name of the claim that returns the user's email address from the identity provider.
                                 type: string
                               firstName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's first name from the identity provider.
+                                  (String) User's first name retrieved from identity provider.
                                   The name of the claim that returns the user's first name from the identity provider.
                                 type: string
                               lastName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's last name from the identity provider.
+                                  (String) User's last name retrieved from identity provider.
                                   The name of the claim that returns the user's last name from the identity provider.
                                 type: string
                               spectroTeam:
                                 description: |-
-                                  (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                                  (String) The SpectroCloud team the user belongs to.
                                   The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                                 type: string
                             type: object
@@ -194,7 +194,7 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             User's email address retrieved from identity provider.
                           type: string
                         enableSingleLogout:
@@ -204,7 +204,7 @@ spec:
                           type: boolean
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             User's first name retrieved from identity provider.
                           type: string
                         identityProviderMetadata:
@@ -214,7 +214,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             User's last name retrieved from identity provider.
                           type: string
                         nameIdFormat:
@@ -229,7 +229,7 @@ spec:
                           type: string
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The SpectroCloud team the user belongs to.
                           type: string
                       type: object
@@ -302,12 +302,12 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             The name of the claim that returns the user's email address from the identity provider.
                           type: string
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             The name of the claim that returns the user's first name from the identity provider.
                           type: string
                         identityProviderCaCertificate:
@@ -327,7 +327,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             The name of the claim that returns the user's last name from the identity provider.
                           type: string
                         scopes:
@@ -340,7 +340,7 @@ spec:
                           x-kubernetes-list-type: set
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                           type: string
                         userInfoEndpoint:
@@ -351,22 +351,22 @@ spec:
                             properties:
                               email:
                                 description: |-
-                                  (String) The name of the claim that returns the user's email address from the identity provider.
+                                  (String) User's email address retrieved from identity provider.
                                   The name of the claim that returns the user's email address from the identity provider.
                                 type: string
                               firstName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's first name from the identity provider.
+                                  (String) User's first name retrieved from identity provider.
                                   The name of the claim that returns the user's first name from the identity provider.
                                 type: string
                               lastName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's last name from the identity provider.
+                                  (String) User's last name retrieved from identity provider.
                                   The name of the claim that returns the user's last name from the identity provider.
                                 type: string
                               spectroTeam:
                                 description: |-
-                                  (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                                  (String) The SpectroCloud team the user belongs to.
                                   The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                                 type: string
                             type: object
@@ -391,7 +391,7 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             User's email address retrieved from identity provider.
                           type: string
                         enableSingleLogout:
@@ -401,7 +401,7 @@ spec:
                           type: boolean
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             User's first name retrieved from identity provider.
                           type: string
                         identityProviderMetadata:
@@ -411,7 +411,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             User's last name retrieved from identity provider.
                           type: string
                         nameIdFormat:
@@ -426,7 +426,7 @@ spec:
                           type: string
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The SpectroCloud team the user belongs to.
                           type: string
                       type: object
@@ -543,12 +543,12 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             The name of the claim that returns the user's email address from the identity provider.
                           type: string
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             The name of the claim that returns the user's first name from the identity provider.
                           type: string
                         identityProviderCaCertificate:
@@ -568,7 +568,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             The name of the claim that returns the user's last name from the identity provider.
                           type: string
                         logoutUrl:
@@ -586,7 +586,7 @@ spec:
                           x-kubernetes-list-type: set
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                           type: string
                         userInfoEndpoint:
@@ -597,22 +597,22 @@ spec:
                             properties:
                               email:
                                 description: |-
-                                  (String) The name of the claim that returns the user's email address from the identity provider.
+                                  (String) User's email address retrieved from identity provider.
                                   The name of the claim that returns the user's email address from the identity provider.
                                 type: string
                               firstName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's first name from the identity provider.
+                                  (String) User's first name retrieved from identity provider.
                                   The name of the claim that returns the user's first name from the identity provider.
                                 type: string
                               lastName:
                                 description: |-
-                                  (String) The name of the claim that returns the user's last name from the identity provider.
+                                  (String) User's last name retrieved from identity provider.
                                   The name of the claim that returns the user's last name from the identity provider.
                                 type: string
                               spectroTeam:
                                 description: |-
-                                  (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                                  (String) The SpectroCloud team the user belongs to.
                                   The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
                                 type: string
                             type: object
@@ -640,7 +640,7 @@ spec:
                           x-kubernetes-list-type: set
                         email:
                           description: |-
-                            (String) The name of the claim that returns the user's email address from the identity provider.
+                            (String) User's email address retrieved from identity provider.
                             User's email address retrieved from identity provider.
                           type: string
                         enableSingleLogout:
@@ -655,7 +655,7 @@ spec:
                           type: string
                         firstName:
                           description: |-
-                            (String) The name of the claim that returns the user's first name from the identity provider.
+                            (String) User's first name retrieved from identity provider.
                             User's first name retrieved from identity provider.
                           type: string
                         identityProviderMetadata:
@@ -670,7 +670,7 @@ spec:
                           type: string
                         lastName:
                           description: |-
-                            (String) The name of the claim that returns the user's last name from the identity provider.
+                            (String) User's last name retrieved from identity provider.
                             User's last name retrieved from identity provider.
                           type: string
                         loginUrl:
@@ -700,7 +700,7 @@ spec:
                           type: string
                         spectroTeam:
                           description: |-
-                            (String) The name of the claim that returns the user's group memberships from the Identity Provider. The values of this claim will map to SpectroCloud teams.
+                            (String) The SpectroCloud team the user belongs to.
                             The SpectroCloud team the user belongs to.
                           type: string
                       type: object


### PR DESCRIPTION
- **chore: make generate**
- **feat: mark AWS access key as sensitive in resource configuration**
- **chore: make generate**

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
